### PR TITLE
Added 2 more Step extensions to shorten syntax when using async methods

### DIFF
--- a/src/NScenario.Demo/UnitTest1.cs
+++ b/src/NScenario.Demo/UnitTest1.cs
@@ -45,7 +45,6 @@ namespace NScenario.Demo
                 await Task.Yield();
                 return valFromStep1 + 1;
             });
-            
             await scenario.Step("This is the third step", () =>
             {
                 // Here comes the logic
@@ -103,6 +102,7 @@ namespace NScenario.Demo
                 });
             });
         }
+
         private static Task<int> Sum(int a, int b)
         {
             return Task.FromResult(a + b);

--- a/src/NScenario.Demo/UnitTest1.cs
+++ b/src/NScenario.Demo/UnitTest1.cs
@@ -45,7 +45,7 @@ namespace NScenario.Demo
                 await Task.Yield();
                 return valFromStep1 + 1;
             });
-
+            
             await scenario.Step("This is the third step", () =>
             {
                 // Here comes the logic
@@ -78,6 +78,17 @@ namespace NScenario.Demo
             });
         }
 
+        [Test]
+        public async Task should_be_able_to_use_tasks_without_function()
+        {
+            var scenario = TestScenarioFactory.Default();
+
+            await scenario.Step("This is step which waits for 100 ms", Task.Delay(100));
+
+            var x = await scenario.Step("This is step which uses Task with result", Sum(5, 10));
+            Assert.AreEqual(15, x);
+        }
+
         private static async Task PerformReusableScenarioPart(ITestScenario scenario)
         {
             await scenario.Step("This is the second step", async () =>
@@ -91,6 +102,10 @@ namespace NScenario.Demo
                     // Here comes the logic
                 });
             });
+        }
+        private static Task<int> Sum(int a, int b)
+        {
+            return Task.FromResult(a + b);
         }
     }
 }

--- a/src/NScenario/TestScenarioExtensions.cs
+++ b/src/NScenario/TestScenarioExtensions.cs
@@ -19,5 +19,19 @@ namespace NScenario
             await scenarioStepExecutor.Step(description, () => { result = action(); }, filePath, methodName, lineNumber);
             return result;
         }
+
+        public static async Task<T> Step<T>(this ITestScenario scenarioStepExecutor, string description, Task<T> task,
+            [CallerFilePath] string filePath = "", [CallerMemberName] string methodName = "", [CallerLineNumber] int lineNumber = 0)
+        {
+            T result = default(T);
+            await scenarioStepExecutor.Step(description, async () => { result = await task; }, filePath, methodName, lineNumber);
+            return result;
+        }
+
+        public static async Task Step(this ITestScenario scenarioStepExecutor, string description, Task task,
+            [CallerFilePath] string filePath = "", [CallerMemberName] string methodName = "", [CallerLineNumber] int lineNumber = 0)
+        {
+            await scenarioStepExecutor.Step(description, async () => await task, filePath, methodName, lineNumber);
+        }
     }
 }


### PR DESCRIPTION
Added 2 more Step extensions to shorten syntax when using async methods.

Following is now valid syntax:
```
var result = await scenario.Step("Description", taskWithResult);
await scenario.Step("Description", taskWithoutResult);
```

You can also see should_be_able_to_use_tasks_without_function in demo